### PR TITLE
Debug emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ iex> body = %{
 iex> Mailjex.Delivery.send(body)
 ```
 
+## Development Mode
+
+When running in development or test environments you may not want to actually send emails. You can disable the sending of email and instead have the body of your request logged to the screen.
+
+You can do this by setting `development_mode: true` in your configuration file for your environment.
+
 ## For more information, see the Hex docs
 
 You can read the docs [here](https://hexdocs.pm/mailjex)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Elixir wrapper for the MailJet API.
 
 ```elixir
 def deps do
-  [{:mailjex, "~> 0.1.1"}]
+  [{:mailjex, "~> 0.1.2"}]
 end
 ```
 
@@ -34,6 +34,7 @@ config :mailjex,
   api_base: "https://api.mailjet.com/v3",
   public_api_key: "<your public key>",
   private_api_key: "<your private key>"
+  development_mode: true | false
 ```
 
 4. Example usage:

--- a/lib/mailjex/utils/comms.ex
+++ b/lib/mailjex/utils/comms.ex
@@ -3,6 +3,7 @@ defmodule Mailjex.Utils.Comms do
   @api_base Application.fetch_env!(:mailjex, :api_base)
   @public_api_key Application.fetch_env!(:mailjex, :public_api_key)
   @private_api_key Application.fetch_env!(:mailjex, :private_api_key)
+  @development_mode Application.fetch_env!(:mailjex, :development_mode)
 
   def request(:get, path) do
     path
@@ -14,9 +15,14 @@ defmodule Mailjex.Utils.Comms do
     hdrs = [body: Poison.encode!(body)]
     |> headers
 
-    path
-    |> api_url
-    |> HTTPotion.post(hdrs)
+    if @development_mode do
+      IO.inspect(hdrs)
+      %HTTPotion.Response{body: hdrs, headers: [], status_code: 200}
+    else
+      path
+      |> api_url
+      |> HTTPotion.post(hdrs)
+    end
   end
 
   def request(:put, path, body) do

--- a/lib/mailjex/utils/comms.ex
+++ b/lib/mailjex/utils/comms.ex
@@ -16,8 +16,10 @@ defmodule Mailjex.Utils.Comms do
     |> headers
 
     if @development_mode do
-      IO.inspect(hdrs)
-      %HTTPotion.Response{body: hdrs, headers: [], status_code: 200}
+      IO.puts "Development Mode Enabled"
+      IO.inspect(body, label: "Body")
+      IO.inspect(hdrs, label: "Headers")
+      %HTTPotion.Response{body: "", headers: [], status_code: 200}
     else
       path
       |> api_url

--- a/lib/mailjex/utils/comms.ex
+++ b/lib/mailjex/utils/comms.ex
@@ -16,9 +16,9 @@ defmodule Mailjex.Utils.Comms do
     |> headers
 
     if @development_mode do
-      IO.puts "Development Mode Enabled"
-      IO.inspect(body, label: "Body")
-      IO.inspect(hdrs, label: "Headers")
+      IO.puts "Mailjex Development Mode Enabled"
+      IO.inspect(body, label: "Mailjex Body")
+      IO.inspect(hdrs, label: "Mailjex Headers")
       %HTTPotion.Response{body: "", headers: [], status_code: 200}
     else
       path

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Mailjex.Mixfile do
 
   defp package do
     [
-      maintainers: ["overture8"],
+      maintainers: ["overture8", "tosbourn"],
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/PiggyPot/mailjex"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mailjex.Mixfile do
 
   def project do
     [app: :mailjex,
-     version: "0.1.1",
+     version: "0.1.2",
      description: "Elixir wrapper for the MailJet API",
      package: package(),
      elixir: "~> 1.4",


### PR DESCRIPTION
This allows for development_mode to be set. When in development mode MailJet will not receive any send requests and instead the body and headers of the request are put out to the terminal.