### PR TITLE
Stop using module @attributes for config from Application.fetch_env

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ end
 
 then...
 
-```elixir
+```sh
 mix deps.get
 ```
 
 
-2. Ensure `mailjex` is started before your application:
+2. Ensure `mailjex` is started before your application (not required for Elixir >= 1.4)
 
 ```elixir
 def application do

--- a/lib/mailjex/api/message.ex
+++ b/lib/mailjex/api/message.ex
@@ -4,7 +4,6 @@ defmodule Mailjex.Api.Message do
 
   def list(params \\ %{}) do
     url_params = params |> URI.encode_query
-    IO.inspect url_params
 
     request(:get, "/REST/message?#{url_params}")
     |> decode_json

--- a/lib/mailjex/utils/comms.ex
+++ b/lib/mailjex/utils/comms.ex
@@ -1,9 +1,10 @@
 defmodule Mailjex.Utils.Comms do
   @moduledoc false
   require Logger
-  @api_base Application.fetch_env!(:mailjex, :api_base)
-  @public_api_key Application.fetch_env!(:mailjex, :public_api_key)
-  @private_api_key Application.fetch_env!(:mailjex, :private_api_key)
+
+  defp api_base, do: Application.fetch_env!(:mailjex, :api_base)
+  defp public_api_key, do: Application.fetch_env!(:mailjex, :public_api_key)
+  defp private_api_key, do: Application.fetch_env!(:mailjex, :private_api_key)
 
   def request(:get, path) do
     path
@@ -53,12 +54,12 @@ defmodule Mailjex.Utils.Comms do
   end
 
   defp api_url(url) do
-    @api_base <> url
+    api_base() <> url
   end
 
   defp headers, do: headers([])
   defp headers(body) do
-    basic_auth = "#{@public_api_key}:#{@private_api_key}" |> Base.encode64
+    basic_auth = "#{public_api_key()}:#{private_api_key()}" |> Base.encode64
     [headers: ["Authorization": "Basic #{basic_auth}",
                "Accepts": "application/json",
                "Content-Type": "application/json"]] ++ body


### PR DESCRIPTION
Unless the build/release is created on a machine that has the correct environment variables set, the fact that Mailjex uses `@public_api_key` `@private_api_key` and `@api_base` makes it impossible to configure this using environment variables as attributes are cached at compile-time.

I've simply updated it to use a function (that isn't cached, naturally).