### PR TITLE
Use custom credentials when sending a message

### DIFF
--- a/lib/mailjex/api/delivery.ex
+++ b/lib/mailjex/api/delivery.ex
@@ -1,9 +1,9 @@
 defmodule Mailjex.Api.Delivery do
   @moduledoc false
   import Mailjex.Utils.Comms
-  
-  def send(body) do
-    request(:post, "/send", body)
+
+  def send(body, public_key \\ nil, private_key \\ nil) do
+    request(:post, "/send", body, public_key, private_key)
     |> decode_json
   end
 end

--- a/lib/mailjex/delivery.ex
+++ b/lib/mailjex/delivery.ex
@@ -35,15 +35,15 @@ defmodule Mailjex.Delivery do
       ...>}
       iex> Mailjex.Delivery.send(body)
   """
-  def send(body) do
-    GenServer.call(__MODULE__, {:send, body})
+  def send(body, public_key \\ nil, private_key \\ nil) do
+    GenServer.call(__MODULE__, {:send, body, public_key, private_key})
   end
 
   ##########################
   # GenServer Callbacks
   ##########################
 
-  def handle_call({:send, body}, _from, state) do
-    {:reply, Delivery.send(body), state}
+  def handle_call({:send, body, public_key, private_key}, _from, state) do
+    {:reply, Delivery.send(body, public_key, private_key), state}
   end
 end

--- a/lib/mailjex/utils/comms.ex
+++ b/lib/mailjex/utils/comms.ex
@@ -12,9 +12,10 @@ defmodule Mailjex.Utils.Comms do
     |> HTTPotion.get(headers())
   end
 
-  def request(:post, path, body) do
+  def request(method, path, body, public_key \\ nil, private_key \\ nil)
+  def request(:post, path, body, public_key, private_key) do
     hdrs = [body: Poison.encode!(body)]
-    |> headers
+    |> headers(public_key, private_key)
 
     development_mode = case Application.fetch_env(:mailjex, :development_mode) do
       {:ok, true} -> true
@@ -32,9 +33,9 @@ defmodule Mailjex.Utils.Comms do
     end
   end
 
-  def request(:put, path, body) do
+  def request(:put, path, body, public_key, private_key) do
     hdrs = [body: Poison.encode!(body)]
-    |> headers
+    |> headers(public_key, private_key)
 
     path
     |> api_url
@@ -58,8 +59,8 @@ defmodule Mailjex.Utils.Comms do
   end
 
   defp headers, do: headers([])
-  defp headers(body) do
-    basic_auth = "#{public_api_key()}:#{private_api_key()}" |> Base.encode64
+  defp headers(body, public_key \\ nil, private_key \\ nil) do
+    basic_auth = "#{public_key || public_api_key()}:#{private_key || private_api_key()}" |> Base.encode64
     [headers: ["Authorization": "Basic #{basic_auth}",
                "Accepts": "application/json",
                "Content-Type": "application/json"]] ++ body


### PR DESCRIPTION
I found it useful to customize each request with different api public and private keys, since we are using the library in a multi user setting.

If you think this could be useful I can extend this to the rest of the APIs as well.